### PR TITLE
Fixing fragment crushing

### DIFF
--- a/src/app/src/main/java/com/example/qrcheckin/core/Database.java
+++ b/src/app/src/main/java/com/example/qrcheckin/core/Database.java
@@ -308,7 +308,7 @@ public class Database {
                 }
                 if (querySnapshots != null) {
                     Log.d("Firestore", "Event list changed " + querySnapshots.size());
-                    eventList.clear();
+                    mEventArrayAdaptor.getValue().getEvents().clear();
                     for (QueryDocumentSnapshot doc: querySnapshots) {
                         DocumentReference hostRef = doc.getDocumentReference("host");
                         Log.d("Firestore", "Event fetched " + doc.getId());

--- a/src/app/src/main/java/com/example/qrcheckin/core/EventArrayAdaptor.java
+++ b/src/app/src/main/java/com/example/qrcheckin/core/EventArrayAdaptor.java
@@ -36,6 +36,10 @@ public class EventArrayAdaptor extends ArrayAdapter<Event> {
         this.context = context;
     }
 
+    public ArrayList<Event> getEvents() {
+        return events;
+    }
+
     /**
      * Get the view of the event
      * @param position the position of the event

--- a/src/app/src/main/java/com/example/qrcheckin/core/User.java
+++ b/src/app/src/main/java/com/example/qrcheckin/core/User.java
@@ -1,9 +1,11 @@
 package com.example.qrcheckin.core;
 
+import java.io.Serializable;
+
 /**
  * The user class which connects with the database and uses the app
  */
-public class User {
+public class User implements Serializable {
     private String id;
     private String name;
     private String email;

--- a/src/app/src/main/java/com/example/qrcheckin/core/UserList.java
+++ b/src/app/src/main/java/com/example/qrcheckin/core/UserList.java
@@ -2,13 +2,14 @@ package com.example.qrcheckin.core;
 
 import com.example.qrcheckin.core.User;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
 /**
  * This is a class which keeps track of a list of user objects (the people who are attending an event)
  */
-public class UserList {
+public class UserList implements Serializable {
     private ArrayList<User> users;
 
     /**

--- a/src/app/src/main/java/com/example/qrcheckin/user/exploreevent/ExploreEventFragment.java
+++ b/src/app/src/main/java/com/example/qrcheckin/user/exploreevent/ExploreEventFragment.java
@@ -1,5 +1,8 @@
 package com.example.qrcheckin.user.exploreevent;
 
+import static com.example.qrcheckin.core.Database.onEventListChanged;
+
+import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.ViewModelProvider;
 
 import android.os.Bundle;
@@ -15,11 +18,14 @@ import android.view.ViewGroup;
 import android.widget.AdapterView;
 import android.widget.ListView;
 
+import com.example.qrcheckin.QRCheckInApplication;
 import com.example.qrcheckin.R;
 import com.example.qrcheckin.core.Event;
+import com.example.qrcheckin.core.EventArrayAdaptor;
 import com.example.qrcheckin.databinding.FragmentExploreEventBinding;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 
 /**
  * The fragment for exploring available events
@@ -51,9 +57,14 @@ public class ExploreEventFragment extends Fragment {
         View root = binding.getRoot();
 
         listView = binding.exploreEventListView;
-        exploreEventViewModel.initializeAdaptor(getContext());
+//        exploreEventViewModel.initializeAdaptor(getContext());
+        ArrayList<Event> events = new ArrayList<>();
+        // TODO: refactor MutableLiveData to only array adaptor
+        MutableLiveData<EventArrayAdaptor> mEventArrayAdaptor = new MutableLiveData<>(new EventArrayAdaptor(requireContext(), events));
 
-        exploreEventViewModel.getEventList().observe(getViewLifecycleOwner(), listView::setAdapter);
+        onEventListChanged(events, mEventArrayAdaptor, ((QRCheckInApplication) requireContext().getApplicationContext()).getCurrentUser().getId(), "explore");
+        listView.setAdapter(mEventArrayAdaptor.getValue());
+//        exploreEventViewModel.getEventList().observe(getViewLifecycleOwner(), listView::setAdapter);
 
         return root;
     }

--- a/src/app/src/main/java/com/example/qrcheckin/user/exploreevent/ExploreEventViewModel.java
+++ b/src/app/src/main/java/com/example/qrcheckin/user/exploreevent/ExploreEventViewModel.java
@@ -2,12 +2,8 @@ package com.example.qrcheckin.user.exploreevent;
 
 import static com.example.qrcheckin.core.Database.onEventListChanged;
 
-import static java.security.AccessController.getContext;
-
 import android.content.Context;
-import android.util.Log;
 
-import androidx.annotation.Nullable;
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.ViewModel;
@@ -15,38 +11,27 @@ import androidx.lifecycle.ViewModel;
 import com.example.qrcheckin.QRCheckInApplication;
 import com.example.qrcheckin.core.Event;
 import com.example.qrcheckin.core.EventArrayAdaptor;
-import com.example.qrcheckin.core.IncrementableInt;
 import com.example.qrcheckin.core.User;
-import com.google.android.gms.tasks.OnSuccessListener;
-import com.google.firebase.firestore.CollectionReference;
-import com.google.firebase.firestore.DocumentReference;
-import com.google.firebase.firestore.DocumentSnapshot;
-import com.google.firebase.firestore.EventListener;
-import com.google.firebase.firestore.FirebaseFirestore;
-import com.google.firebase.firestore.FirebaseFirestoreException;
-import com.google.firebase.firestore.QueryDocumentSnapshot;
-import com.google.firebase.firestore.QuerySnapshot;
 
 import java.util.ArrayList;
-import java.util.Objects;
 
 public class ExploreEventViewModel extends ViewModel {
-    private final MutableLiveData<EventArrayAdaptor> mEventArrayAdaptor;
-    private final ArrayList<Event> eventList;
-    private User currentUser;
+//    private final MutableLiveData<EventArrayAdaptor> mEventArrayAdaptor;
+//    private final ArrayList<Event> eventList;
+//    private User currentUser;
     /**
      * Initializes the ExploreEventViewModel class
      */
     public ExploreEventViewModel() {
-        mEventArrayAdaptor = new MutableLiveData<EventArrayAdaptor>();
-        eventList = new ArrayList<Event>();
+//        mEventArrayAdaptor = new MutableLiveData<EventArrayAdaptor>();
+//        eventList = new ArrayList<Event>();
     }
-    public void initializeAdaptor(Context context) {
-        mEventArrayAdaptor.setValue(new EventArrayAdaptor(context, eventList));
-        onEventListChanged(eventList, mEventArrayAdaptor, ((QRCheckInApplication) context.getApplicationContext()).getCurrentUser().getId(), "explore");
-    }
+//    public void initializeAdaptor(Context context) {
+//        mEventArrayAdaptor.setValue(new EventArrayAdaptor(context, eventList));
+//        onEventListChanged(eventList, mEventArrayAdaptor, ((QRCheckInApplication) context.getApplicationContext()).getCurrentUser().getId(), "explore");
+//    }
 
-    public LiveData<EventArrayAdaptor> getEventList() {
-        return mEventArrayAdaptor;
-    }
+//    public LiveData<EventArrayAdaptor> getEventList() {
+//        return mEventArrayAdaptor;
+//    }
 }

--- a/src/app/src/main/java/com/example/qrcheckin/user/hostedevent/HostedEventFragment.java
+++ b/src/app/src/main/java/com/example/qrcheckin/user/hostedevent/HostedEventFragment.java
@@ -1,5 +1,9 @@
 package com.example.qrcheckin.user.hostedevent;
 
+import static com.example.qrcheckin.core.Database.onEventListChanged;
+
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.ViewModelProvider;
 
 import android.os.Bundle;
@@ -9,6 +13,7 @@ import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import androidx.navigation.Navigation;
 
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -17,11 +22,15 @@ import android.widget.Button;
 import android.widget.ListView;
 import android.widget.TextView;
 
+import com.example.qrcheckin.QRCheckInApplication;
 import com.example.qrcheckin.R;
 import com.example.qrcheckin.core.Event;
+import com.example.qrcheckin.core.EventArrayAdaptor;
 import com.example.qrcheckin.databinding.FragmentHostedEventBinding;
 
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Objects;
 
 /**
  * A fragment which contains a list of events the user is hosting
@@ -52,9 +61,14 @@ public class HostedEventFragment extends Fragment {
         View root = binding.getRoot();
 
         listView = binding.hostedEventListView;
-        hostedEventViewModel.initializeAdaptor(getContext());
+//        hostedEventViewModel.initializeAdaptor(getContext());
+        ArrayList<Event> eventList = new ArrayList<>();
+        // TODO: refactor MutableLiveData to only array adaptor
+        MutableLiveData<EventArrayAdaptor> mEventArrayAdaptor = new MutableLiveData<>(new EventArrayAdaptor(requireContext(), eventList));
 
-        hostedEventViewModel.getEventList().observe(getViewLifecycleOwner(), listView::setAdapter);
+        onEventListChanged(eventList, mEventArrayAdaptor, ((QRCheckInApplication) requireContext().getApplicationContext()).getCurrentUser().getId(), "hosted");
+        listView.setAdapter(mEventArrayAdaptor.getValue());
+//        hostedEventViewModel.getEventList().observe(getViewLifecycleOwner(), listView::setAdapter);
         return root;
     }
 
@@ -73,7 +87,6 @@ public class HostedEventFragment extends Fragment {
                 Event event = (Event) listView.getItemAtPosition(position);
                 Bundle bundle = new Bundle();
                 bundle.putSerializable("event", (Serializable) event);
-                // TODO: define it to change to the edit event page
                 Navigation.findNavController(requireView()).navigate(R.id.action_nav_host_event_to_nav_edit_event, bundle);
             }
         });
@@ -92,6 +105,7 @@ public class HostedEventFragment extends Fragment {
      */
     @Override
     public void onDestroyView() {
+        Log.d("HostedEventFragment", "onDestroyView");
         super.onDestroyView();
         binding = null;
     }

--- a/src/app/src/main/java/com/example/qrcheckin/user/hostedevent/HostedEventViewModel.java
+++ b/src/app/src/main/java/com/example/qrcheckin/user/hostedevent/HostedEventViewModel.java
@@ -1,7 +1,5 @@
 package com.example.qrcheckin.user.hostedevent;
 
-import static com.example.qrcheckin.core.Database.onEventListChanged;
-
 import android.content.Context;
 import android.util.Log;
 
@@ -11,38 +9,28 @@ import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.ViewModel;
 
 import com.example.qrcheckin.QRCheckInApplication;
+import com.example.qrcheckin.core.Database;
 import com.example.qrcheckin.core.Event;
 import com.example.qrcheckin.core.EventArrayAdaptor;
-import com.example.qrcheckin.core.IncrementableInt;
-import com.example.qrcheckin.core.User;
-import com.google.android.gms.tasks.OnSuccessListener;
-import com.google.firebase.firestore.CollectionReference;
-import com.google.firebase.firestore.DocumentReference;
-import com.google.firebase.firestore.DocumentSnapshot;
-import com.google.firebase.firestore.EventListener;
-import com.google.firebase.firestore.FirebaseFirestore;
-import com.google.firebase.firestore.FirebaseFirestoreException;
-import com.google.firebase.firestore.QueryDocumentSnapshot;
-import com.google.firebase.firestore.QuerySnapshot;
 
 import java.util.ArrayList;
 import java.util.Objects;
 
 public class HostedEventViewModel extends ViewModel {
-    private final MutableLiveData<EventArrayAdaptor> mEventArrayAdaptor;
-    private final ArrayList<Event> eventList;
+//    private final MutableLiveData<EventArrayAdaptor> mEventArrayAdaptor;
+//    private final ArrayList<Event> eventList;
 
     public HostedEventViewModel() {
-        mEventArrayAdaptor = new MutableLiveData<EventArrayAdaptor>();
-        eventList = new ArrayList<Event>();
+//        mEventArrayAdaptor = new MutableLiveData<EventArrayAdaptor>();
+//        eventList = new ArrayList<Event>();
     }
 
-    public void initializeAdaptor(Context context) {
-        mEventArrayAdaptor.setValue(new EventArrayAdaptor(context, eventList));
-        onEventListChanged(eventList, mEventArrayAdaptor, ((QRCheckInApplication) context.getApplicationContext()).getCurrentUser().getId(), "hosted");
-    }
+//    public void initializeAdaptor(Context context) {
+//        mEventArrayAdaptor.setValue(new EventArrayAdaptor(context, eventList));
+//        onEventListChanged(eventList, mEventArrayAdaptor, ((QRCheckInApplication) context.getApplicationContext()).getCurrentUser().getId(), "hosted");
+//    }
 
-    public LiveData<EventArrayAdaptor> getEventList() {
-        return mEventArrayAdaptor;
-    }
+//    public LiveData<EventArrayAdaptor> getEventList() {
+//        return mEventArrayAdaptor;
+//    }
 }

--- a/src/app/src/main/java/com/example/qrcheckin/user/myevent/EventFragment.java
+++ b/src/app/src/main/java/com/example/qrcheckin/user/myevent/EventFragment.java
@@ -1,5 +1,8 @@
 package com.example.qrcheckin.user.myevent;
 
+import static com.example.qrcheckin.core.Database.onEventListChanged;
+
+import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.ViewModelProvider;
 
 import android.os.Bundle;
@@ -15,11 +18,14 @@ import android.view.ViewGroup;
 import android.widget.AdapterView;
 import android.widget.ListView;
 
+import com.example.qrcheckin.QRCheckInApplication;
 import com.example.qrcheckin.R;
 import com.example.qrcheckin.core.Event;
+import com.example.qrcheckin.core.EventArrayAdaptor;
 import com.example.qrcheckin.databinding.FragmentEventBinding;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 
 /**
  * Fragment which contains a list of the events a user has checked into
@@ -38,9 +44,14 @@ public class EventFragment extends Fragment {
         View root = binding.getRoot();
 
         listView = binding.eventListView;
-        eventViewModel.initializeAdaptor(getContext());
+//        eventViewModel.initializeAdaptor(getContext());
+        ArrayList<Event> events = new ArrayList<>();
+        // TODO: refactor MutableLiveData to only array adaptor
+        MutableLiveData<EventArrayAdaptor> mEventArrayAdaptor = new MutableLiveData<>(new EventArrayAdaptor(getContext(), events));
 
-        eventViewModel.getEventList().observe(getViewLifecycleOwner(), listView::setAdapter);
+        onEventListChanged(events, mEventArrayAdaptor, ((QRCheckInApplication) requireContext().getApplicationContext()).getCurrentUser().getId(), "my");
+        listView.setAdapter(mEventArrayAdaptor.getValue());
+//        eventViewModel.getEventList().observe(getViewLifecycleOwner(), listView::setAdapter);
 
         return root;
     }

--- a/src/app/src/main/java/com/example/qrcheckin/user/myevent/EventViewModel.java
+++ b/src/app/src/main/java/com/example/qrcheckin/user/myevent/EventViewModel.java
@@ -5,8 +5,6 @@ import static com.example.qrcheckin.core.Database.onEventListChanged;
 import android.content.Context;
 import android.util.Log;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.ViewModel;
@@ -14,38 +12,24 @@ import androidx.lifecycle.ViewModel;
 import com.example.qrcheckin.QRCheckInApplication;
 import com.example.qrcheckin.core.Event;
 import com.example.qrcheckin.core.EventArrayAdaptor;
-import com.example.qrcheckin.core.IncrementableInt;
-import com.example.qrcheckin.core.User;
-import com.google.android.gms.tasks.OnCompleteListener;
-import com.google.android.gms.tasks.OnSuccessListener;
-import com.google.android.gms.tasks.Task;
-import com.google.firebase.firestore.CollectionReference;
-import com.google.firebase.firestore.DocumentReference;
-import com.google.firebase.firestore.DocumentSnapshot;
-import com.google.firebase.firestore.EventListener;
-import com.google.firebase.firestore.FirebaseFirestore;
-import com.google.firebase.firestore.FirebaseFirestoreException;
-import com.google.firebase.firestore.QueryDocumentSnapshot;
-import com.google.firebase.firestore.QuerySnapshot;
 
 import java.util.ArrayList;
-import java.util.Objects;
 
 public class EventViewModel extends ViewModel {
-    private final MutableLiveData<EventArrayAdaptor> mEventArrayAdaptor;
-    private final ArrayList<Event> eventList;
+//    private final MutableLiveData<EventArrayAdaptor> mEventArrayAdaptor;
+//    private final ArrayList<Event> eventList;
 
     public EventViewModel() {
-        mEventArrayAdaptor = new MutableLiveData<EventArrayAdaptor>();
-        eventList = new ArrayList<Event>();
+//        mEventArrayAdaptor = new MutableLiveData<EventArrayAdaptor>();
+//        eventList = new ArrayList<Event>();
     }
 
-    public void initializeAdaptor(Context context) {
-        mEventArrayAdaptor.setValue(new EventArrayAdaptor(context, eventList));
-        onEventListChanged(eventList, mEventArrayAdaptor, ((QRCheckInApplication) context.getApplicationContext()).getCurrentUser().getId(), "my");
-    }
+//    public void initializeAdaptor(Context context) {
+//        mEventArrayAdaptor.setValue(new EventArrayAdaptor(context, eventList));
+//        onEventListChanged(eventList, mEventArrayAdaptor, ((QRCheckInApplication) context.getApplicationContext()).getCurrentUser().getId(), "my");
+//    }
 
-    public LiveData<EventArrayAdaptor> getEventList() {
-        return mEventArrayAdaptor;
-    }
+//    public LiveData<EventArrayAdaptor> getEventList() {
+//        return mEventArrayAdaptor;
+//    }
 }

--- a/src/app/src/main/res/navigation/mobile_navigation.xml
+++ b/src/app/src/main/res/navigation/mobile_navigation.xml
@@ -70,7 +70,7 @@
     <fragment
         android:id="@+id/nav_create_notifications"
         android:name="com.example.qrcheckin.user.createnotification.CreateNotificationFragment"
-        android:label="CreateNotifications"
+        android:label="Create Notification"
         tools:layout="@layout/fragment_create_notification" />
 
     <fragment
@@ -82,25 +82,25 @@
     <fragment
         android:id="@+id/nav_all_images"
         android:name="com.example.qrcheckin.admin.allimages.AllImagesFragment"
-        android:label="@string/nav_all_event"
+        android:label="All Images"
         tools:layout="@layout/fragment_all_images" />
 
     <fragment
         android:id="@+id/nav_all_profile"
         android:name="com.example.qrcheckin.admin.allprofiles.AllProfilesFragment"
-        android:label="@string/nav_all_event"
+        android:label="All Profiles"
         tools:layout="@layout/fragment_all_profiles" />
 
     <fragment
         android:id="@+id/nav_view_event"
         android:name="com.example.qrcheckin.user.viewEvent.ViewEventFragment"
-        android:label="view_event"
+        android:label="Event"
         tools:layout="@layout/fragment_view_event" />
 
     <fragment
         android:id="@+id/nav_create_event"
         android:name="com.example.qrcheckin.user.createevent.CreateEventFragment"
-        android:label="create_event"
+        android:label="Create Event"
         tools:layout="@layout/fragment_create_event">
     </fragment>
 

--- a/src/app/src/main/res/navigation/mobile_navigation.xml
+++ b/src/app/src/main/res/navigation/mobile_navigation.xml
@@ -39,10 +39,12 @@
         android:name="com.example.qrcheckin.user.editevent.EditEventFragment"
         android:label="Edit Events"
         tools:layout="@layout/fragment_edit_event"
-        />
+        >
         <action
             android:id="@+id/action_nav_edit_event_to_nav_create_notification"
             app:destination="@id/nav_create_notifications"/>
+    </fragment>
+
     <fragment
         android:id="@+id/nav_explore_event"
         android:name="com.example.qrcheckin.user.exploreevent.ExploreEventFragment"


### PR DESCRIPTION
- Fixed the bug for when switching between pages, it sets more than one listener onto the eventlists
- Fixed crushing issue for when switching apps on a new fragment
- Change the Wrong names on pages